### PR TITLE
fix missing dependency for non-bowser apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   },
   "url": "https://example.com/path/to/your/plugin",
   "repository": "juddey/ignite-react-native-navigation",
+  "dependencies": {
+    "fs-jetpack": "^1.0.0"
+  },
   "devDependencies": {
-    "fs-jetpack": "^1.0.0",
     "jest": "^20.0.4",
     "np": "^2.12.0",
     "prettier": "^1.13.5",


### PR DESCRIPTION
Fixes the first issue in #3, not sure about the second

Currently adding this plugin to an existing project can fail on the missing dependency `fs-jetpack` (for exampe in an `andross` app).  It works on `bowser`, because as `yarn why fs-jetpack` explains:
```
=> Found "fs-jetpack@1.3.1"
info Reasons this module exists
   - "solidarity#gluegun" depends on it
   - Hoisted from "solidarity#gluegun#fs-jetpack"
```

```
/tmp/react-native-nav-testing/TestApp(master*) » ignite add ignite-react-native-navigation --debug                            ruddell@Jons-MacBook-Pro

19:36:00 [ignite] running add command
19:36:00 [ignite] installing /private/tmp/react-native-nav-testing/TestApp/node_modules/ignite-react-native-navigation from source npm
⠇ adding ignite-react-native-navigation19:36:01 [ignite] ignite-react-native-navigation 0.3.0 on npm.
19:36:01 [ignite] yarn add ignite-react-native-navigation --dev
⠋ adding ignite-react-native-navigation19:36:13 [ignite] finished yarn command
19:36:13 [ignite] requiring ignite plugin from /private/tmp/react-native-nav-testing/TestApp/node_modules/ignite-react-native-navigation
✖ problem loading the plugin JS
Rolling back...run with --debug to see more info
19:36:13 [ignite]
  Error: Cannot find module 'fs-jetpack'
  ```